### PR TITLE
chore: update GitHub Actions dependencies to latest

### DIFF
--- a/.github/actions/shared-build-steps/action.yml
+++ b/.github/actions/shared-build-steps/action.yml
@@ -4,21 +4,17 @@ inputs:
     required: true
   dockerhub_password:
     required: true
-  runner_os:
-    required: true
-  github_sha:
-    required: true
 runs:
   using: "composite"
   steps:
     - name: Login to Docker Hub 🔐🐳
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ inputs.dockerhub_user }}
         password: ${{ inputs.dockerhub_password }}
 
     - name: Set up QEMU 🏗️
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: amd64,arm64
 
@@ -28,17 +24,8 @@ runs:
         sudo swapoff -a
         sudo rm -f /swapfile
         sudo apt clean
-        docker rmi $(docker image ls -aq)
+        docker rmi $(docker image ls -aq) || true
         df -h
 
     - name: Set up Docker Buildx 🏗️
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Cache Docker layers 💾
-      uses: actions/cache@v4
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ inputs.runner_os }}-buildx-${{ inputs.github_sha }}
-        restore-keys: |
-          ${{ inputs.runner_os }}-buildx-
+      uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,15 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo ✅
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Job preparation 🛫 # Steps that must be carried out before creating the Docker images
         uses: ./.github/actions/shared-build-steps
         with:
           dockerhub_user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          runner_os: ${{ runner.os }}
-          github_sha: ${{ github.sha }}
 
       - name: Docker meta 💬 # Creating meta information such as the image tag for the Docker image
         id: meta
@@ -30,34 +28,31 @@ jobs:
 
       - name: Build and push mlflow Docker image 🔨🐳
         id: docker_build_mlflow
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/mlflow/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build_mlflow.outputs.digest }}
 
   # This job creates and publishes the jupyter docker images
   build-jupyter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo ✅
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Job preparation 🛫 # Steps that must be carried out before creating the Docker images
         uses: ./.github/actions/shared-build-steps
         with:
           dockerhub_user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          runner_os: ${{ runner.os }}
-          github_sha: ${{ github.sha }}
 
       - name: Docker meta 💬 # Creating meta information such as the image tag for the Docker image
         id: meta
@@ -65,36 +60,33 @@ jobs:
         with:
           images: codecentric/from-jupyter-to-production-jupyter
 
-      - name: Build and push juypter Docker image 🔨🐳
-        id: docker_build_mlflow
-        uses: docker/build-push-action@v2.4.0
+      - name: Build and push jupyter Docker image 🔨🐳
+        id: docker_build_jupyter
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/jupyter/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build_jupyter.outputs.digest }}
 
   # This job creates and publishes the dagster docker images
   build-dagster:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo ✅
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Job preparation 🛫 # Steps that must be carried out before creating the Docker images
         uses: ./.github/actions/shared-build-steps
         with:
           dockerhub_user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          runner_os: ${{ runner.os }}
-          github_sha: ${{ github.sha }}
 
       - name: Docker meta 💬 # Creating meta information such as the image tag for the Docker image
         id: meta
@@ -102,34 +94,32 @@ jobs:
         with:
           images: codecentric/from-jupyter-to-production-dagster
 
-      - name: Build and push juypter Docker image 🔨🐳
+      - name: Build and push dagster Docker image 🔨🐳
         id: docker_build_dagster
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/dagster/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build_dagster.outputs.digest }}
+
   build-code-server:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo ✅
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Job preparation 🛫 # Steps that must be carried out before creating the Docker images
         uses: ./.github/actions/shared-build-steps
         with:
           dockerhub_user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          runner_os: ${{ runner.os }}
-          github_sha: ${{ github.sha }}
 
       - name: Docker meta 💬 # Creating meta information such as the image tag for the Docker image
         id: meta
@@ -138,34 +128,31 @@ jobs:
           images: codecentric/from-jupyter-to-production-code-server
 
       - name: Build and push code-server Docker image 🔨🐳
-        id: docker_build_code-server
-        uses: docker/build-push-action@v2.4.0
+        id: docker_build_code_server
+        uses: docker/build-push-action@v6
         with:
           context: ./docker/code-server
           file: ./docker/code-server/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build_code_server.outputs.digest }}
 
   build-registry:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo ✅
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Job preparation 🛫 # Steps that must be carried out before creating the Docker images
         uses: ./.github/actions/shared-build-steps
         with:
           dockerhub_user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          runner_os: ${{ runner.os }}
-          github_sha: ${{ github.sha }}
 
       - name: Docker meta 💬 # Creating meta information such as the image tag for the Docker image
         id: meta
@@ -175,16 +162,15 @@ jobs:
 
       - name: Build and push registry Docker image 🔨🐳
         id: docker_build_registry
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/registry/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build_registry.outputs.digest }}


### PR DESCRIPTION
- Bump docker/login-action, setup-qemu-action, setup-buildx-action from v1 to v3
- Bump docker/build-push-action from v2 to v6
- Bump actions/checkout from v2 to v4
- Switch Docker layer cache from local to GitHub Actions cache
- Remove unused runner_os and github_sha inputs from shared action
- Fix step IDs and image digest references